### PR TITLE
Remove environment requirement from npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    environment: npm
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The environment name mismatch between GitHub and npm Trusted Publisher config may be causing the E404. Remove it and rely on OIDC without environment constraint.

https://claude.ai/code/session_015ULf7E87jnVstnJxZk8LVU